### PR TITLE
docker-compose.yml 업데이트: 백엔드 서비스 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,16 @@ services:
       - notes
     volumes:
       - ./db:/var/lib/mysql
+  
+  backend:
+    image: lts-backend
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+    ports:
+      - 3031:3031
+    networks:
+      - notes
 
 networks:
   notes:


### PR DESCRIPTION
- 백엔드 서비스 정의
  - backend 서비스 추가: 로컬 빌드된 lts-backend 이미지 사용
  - 환경 변수 설정
    - DB_HOST: db 서비스를 가리키도록 설정 (서비스 간 네트워킹 활용)
    - DB_PORT: 데이터베이스 연결 포트 설정 (기본값 3306)
- 포트 매핑: 컨테이너 포트 (3031)를 호스트 포트 (3031)에 매핑
- 네트워크 연결: notes 네트워크 연결 설정