### PR TITLE
docker-compose.yml 업데이트: MariaDB 서비스 설정 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: "3.8"
 services:
   db:
     image: mariadb:11.2.2
+    container_name: note-mariadb
     environment:
+      TZ: Asia/Seoul
       MARIADB_ROOT_PASSWORD: root
     ports:
       - 3032:3306


### PR DESCRIPTION
컨테이너 이름 설정:
- db 서비스의 컨테이너 이름을 note-mariadb 로 명확하게 설정
  - 시간대 설정 추가:

- environment 블록에 TZ: Asia/Seoul 추가하여 컨테이너 내 시간대를 한국
  - 표준시 (KST)으로 설정