### PR TITLE
fix: Docker build 시 mysql2 모듈 인식 문제를 해결하라

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,6 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "bcrypt": "^5.1.1",
-    "mysql2": "^3.6.5",
     "nodemon": "^3.1.0",
     "typescript": "^5.4.3"
   },
@@ -23,6 +22,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.7",
     "cookie-parser": "^1.4.6",
+    "mysql2": "^3.6.5",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.1",


### PR DESCRIPTION
주요 변경 내용
docker build 시 npm ci 인스톨을 하지 못하는 문제가 발생했습니다.
그 이유는 npm ci 조건에서 dev* 인스톨 하지 않은다는 것이였습니다.

mysql2는 운영에서 사용해야 하는 라이브러리로 devDependencies가 아닌 dependencies에 추가해야 합니다.